### PR TITLE
Feature/eclover

### DIFF
--- a/Grid/qcd/action/fermion/CloverHelpers.h
+++ b/Grid/qcd/action/fermion/CloverHelpers.h
@@ -417,8 +417,8 @@ public:
         pokeLocalSite(triangle_exp_tmp, triangleExp_v, lcoor);
       });
 
-    Diagonal = Diagonal * diag_mass;
-    Triangle = Triangle * diag_mass;
+    Diagonal *= diag_mass;
+    Triangle *= diag_mass;
   }
 
 

--- a/Grid/qcd/action/fermion/CloverHelpers.h
+++ b/Grid/qcd/action/fermion/CloverHelpers.h
@@ -417,6 +417,11 @@ public:
         pokeLocalSite(triangle_exp_tmp, triangleExp_v, lcoor);
       });
 
+    diagonal_v.ViewClose();
+    triangle_v.ViewClose();
+    diagonalExp_v.ViewClose();
+    triangleExp_v.ViewClose();
+
     Diagonal *= diag_mass;
     Triangle *= diag_mass;
   }

--- a/Grid/qcd/action/fermion/CloverHelpers.h
+++ b/Grid/qcd/action/fermion/CloverHelpers.h
@@ -332,7 +332,7 @@ public:
       conformable(Diagonal, Triangle);
 
       long lsites = grid->lSites();
-
+    {
       typedef typename SiteCloverDiagonal::scalar_object scalar_object_diagonal;
       typedef typename SiteCloverTriangle::scalar_object scalar_object_triangle;
       typedef iMatrix<ComplexD,6> mat;
@@ -416,11 +416,7 @@ public:
         pokeLocalSite(diagonal_exp_tmp, diagonalExp_v, lcoor);
         pokeLocalSite(triangle_exp_tmp, triangleExp_v, lcoor);
       });
-
-    diagonal_v.ViewClose();
-    triangle_v.ViewClose();
-    diagonalExp_v.ViewClose();
-    triangleExp_v.ViewClose();
+    }
 
     Diagonal *= diag_mass;
     Triangle *= diag_mass;


### PR DESCRIPTION
I noticed that the compact version of the exponential clover action does not properly run on gpu machines. The fix is a simple set of curly brackets around the `thread_for` operation run on the cpu which lets the `autoview` run out of scope and frees cache locks for the following implicit `acceleratorview` for the multiplication of the diagonal mass.